### PR TITLE
feat(manager): require explicitly defined {{action}}_fields

### DIFF
--- a/ripozo_sqlalchemy/alchemymanager.py
+++ b/ripozo_sqlalchemy/alchemymanager.py
@@ -325,7 +325,7 @@ class AlchemyManager(BaseManager):
         :return: The model with the updated
         :rtype: Model
         """
-        fields = fields or self.fields
+        fields = fields or []
         for name, val in six.iteritems(values):
             if name not in fields:
                 continue


### PR DESCRIPTION
Require create_fields and update_fields to be explicitly defined instead of defaulting to
self.fields.
